### PR TITLE
Check if array index is defined

### DIFF
--- a/lost-password.php
+++ b/lost-password.php
@@ -8,7 +8,7 @@ class WC_Ncr_Lost_Password_Captcha extends WC_Ncr_No_Captcha_Recaptcha {
 	public static function initialize() {
 
 		// initialize if login is activated
-		if ( isset( self::$plugin_options['captcha_wc_lost_password'] ) || self::$plugin_options['captcha_wc_lost_password'] == 'yes' ) {
+		if ( array_key_exists( 'captcha_wc_lost_password', self::$plugin_options ) && ( isset( self::$plugin_options['captcha_wc_lost_password'] ) || self::$plugin_options['captcha_wc_lost_password'] == 'yes' ) ) {
 
 			// adds the captcha to the login form
 			add_filter( 'woocommerce_lostpassword_form', array( __CLASS__, 'display_captcha' ) );


### PR DESCRIPTION
The plugin currently generates a PHP notice about undefined index for 'captcha_wc_lost_password'. This fills up error logs and is untidy.
This fixes that by checking to see if the 'captcha_wc_lost_password' index is defined first.